### PR TITLE
途中で試合をfinishできる

### DIFF
--- a/src/layers/summary/overview.c
+++ b/src/layers/summary/overview.c
@@ -14,9 +14,19 @@ static void render(Layer *layer, GContext *ctx) {
   GRect text_box = { .origin = { .x = 10, .y = 10 }, .size = { .h = 34, .w = (bounds.size.w - 30) / 2 } };
   graphics_fill_rect(ctx, text_box, 5, GCornerNone);
 
+  char* match_result;
+
+  if (state->player_sets > state->opponent_sets) {
+    match_result = "WIN";
+  } else if (state->player_sets < state->opponent_sets) {
+    match_result = "LOSE";
+  } else {
+    match_result = "TIE";
+  }
+
   graphics_draw_text(
       ctx
-    , state->player_sets > state->opponent_sets ? "WIN" : "LOSE"
+    , match_result
     , fonts_get_system_font(FONT_KEY_GOTHIC_24)
     , text_box
     , GTextOverflowModeTrailingEllipsis

--- a/src/layers/summary/overview.c
+++ b/src/layers/summary/overview.c
@@ -21,8 +21,6 @@ static void render(Layer *layer, GContext *ctx) {
     } else if (state->player_games < state->opponent_games) {
       state->opponent_sets++;
     }
-
-    state->is_complete = true;
   }
 
   GRect bounds = layer_get_frame(layer);

--- a/src/layers/summary/overview.c
+++ b/src/layers/summary/overview.c
@@ -5,6 +5,26 @@ static void render(Layer *layer, GContext *ctx) {
   OverviewData *data = (OverviewData *) layer_get_data(layer);
   State *state = data->state;
 
+  int num_sets = state->player_sets + state->opponent_sets;
+
+  // ユーザーが Finish match を選んだ場合はまだ complete でない
+  if (!state->is_complete) {
+    num_sets++;
+
+    int current_set = state->player_sets + state->opponent_sets;
+
+    state->completed_sets[current_set][0] = state->player_games;
+    state->completed_sets[current_set][1] = state->opponent_games;
+
+    if (state->player_games > state->opponent_games) {
+      state->player_sets++;
+    } else if (state->player_games < state->opponent_games) {
+      state->opponent_sets++;
+    }
+
+    state->is_complete = true;
+  }
+
   GRect bounds = layer_get_frame(layer);
 
   graphics_context_set_text_color(ctx, GColorWhite);
@@ -52,7 +72,6 @@ static void render(Layer *layer, GContext *ctx) {
     , NULL);
 
   int width = bounds.size.w - 30;
-  int num_sets = state->player_sets + state->opponent_sets;
   int cell_size = (width / 5);
   int line_width = cell_size * num_sets;
 

--- a/src/layers/summary/overview.c
+++ b/src/layers/summary/overview.c
@@ -5,7 +5,7 @@ static void render(Layer *layer, GContext *ctx) {
   OverviewData *data = (OverviewData *) layer_get_data(layer);
   State *state = data->state;
 
-  int num_sets = state->player_sets + state->opponent_sets;
+  int num_sets = state->player_sets + state->opponent_sets + state->tie_sets;
 
   // ユーザーが Finish match を選んだ場合はまだ complete でない
   if (!state->is_complete) {
@@ -20,7 +20,11 @@ static void render(Layer *layer, GContext *ctx) {
       state->player_sets++;
     } else if (state->player_games < state->opponent_games) {
       state->opponent_sets++;
+    } else {
+      state->tie_sets++;
     }
+
+    state->is_complete = true;
   }
 
   GRect bounds = layer_get_frame(layer);

--- a/src/state.c
+++ b/src/state.c
@@ -43,6 +43,9 @@ State state_new(Settings *settings) {
     , .opponent_break_points_conceded = 0
     , .completed_sets = completed_sets
 
+    // ユーザーが途中で Finish match を選ぶ場合にタイセットがあり得る
+    , .tie_sets = 0
+
     };
 
 }

--- a/src/state.h
+++ b/src/state.h
@@ -45,6 +45,9 @@ typedef struct {
   int opponent_break_points_conceded;
   int **completed_sets;
 
+  // ユーザーが途中で Finish match を選ぶ場合にタイセットがあり得る
+  int tie_sets;
+
 } State;
 
 typedef struct {

--- a/src/windows/in_play_menu.c
+++ b/src/windows/in_play_menu.c
@@ -27,7 +27,7 @@ static void window_load(Window *window) {
   GRect bounds = layer_get_bounds(window_layer);
 
   in_play_menu_sections[0] = (SimpleMenuSection) {
-    .num_items = 2,
+    .num_items = 3,
     .items = in_play_menu_items
   };
 
@@ -42,6 +42,11 @@ static void window_load(Window *window) {
   };
 
   in_play_menu_items[1] = (SimpleMenuItem) {
+    .title = "Finish match",
+    .callback = show_summary
+  };
+
+  in_play_menu_items[2] = (SimpleMenuItem) {
     .title = "Discard match",
     .callback = discard
   };

--- a/src/windows/in_play_menu.c
+++ b/src/windows/in_play_menu.c
@@ -16,6 +16,10 @@ static void discard() {
   menu_window_push();
 }
 
+static void finish() {
+  show_summary();
+}
+
 // static void save() {
 //   save_match(serial);
 //   window_stack_pop_all(true);
@@ -43,7 +47,7 @@ static void window_load(Window *window) {
 
   in_play_menu_items[1] = (SimpleMenuItem) {
     .title = "Finish match",
-    .callback = show_summary
+    .callback = finish,
   };
 
   in_play_menu_items[2] = (SimpleMenuItem) {

--- a/src/windows/in_play_menu.h
+++ b/src/windows/in_play_menu.h
@@ -3,6 +3,7 @@
 
 #include <pebble.h>
 #include "menu.h"
+#include "match.h"
 #include "../state.h"
 #include "../persistence.h"
 

--- a/src/windows/match.c
+++ b/src/windows/match.c
@@ -62,7 +62,7 @@ static void render(State *state) {
   state_destroy(state);
 }
 
-static void show_summary() {
+void show_summary() {
   window_stack_pop_all(true);
   State state = compute_state(serial, &settings);
   summary_window_push(state);

--- a/src/windows/match.h
+++ b/src/windows/match.h
@@ -10,5 +10,6 @@
 
 void match_window_push(Settings *settings, list_t *serial);
 void draw_server_marker();
+void show_summary();
 
 #endif


### PR DESCRIPTION
* [x] 途中で試合をfinishできる
* [x] 途中で試合をfinishした場合でも統計情報が正しく表示される （タイブレイクはサポートしない）

### 追加したメニュー
![finish_match](https://user-images.githubusercontent.com/990875/40281162-ad800f16-5c98-11e8-86a6-5e9852b8c4af.png)
